### PR TITLE
Add local time of current city to homepage

### DIFF
--- a/src/components/CurrentWeather/CurrentWeather.tsx
+++ b/src/components/CurrentWeather/CurrentWeather.tsx
@@ -1,7 +1,7 @@
 import { useGetCurrentWeather } from "../../hooks/useGetCurrentWeather";
 import { RootState } from "../../redux/store";
 import { useSelector } from "react-redux";
-import { getLongDate } from "../../utils/dateUtils";
+import { formatLocalTime, getLongDate } from "../../utils/dateUtils";
 import WeatherTempWindow from "../WeatherTempWindow/WeatherTempWindow";
 import "./CurrentWeather.css";
 import classNames from "classnames";
@@ -15,6 +15,10 @@ const CurrentWeather = () => {
 
   const currentDate: string = getLongDate(
     (currentWeather?.date + timezoneOffset) * 1000
+  );
+
+  const currentTime: string = formatLocalTime(
+    new Date(Date.now() + timezoneOffset * 1000)
   );
 
   if (isWeatherPending || !currentWeather) {
@@ -33,7 +37,8 @@ const CurrentWeather = () => {
   return (
     <div className="current-weather-container main-container">
       <h2 className="no-margin">{currentWeather.cityName}</h2>
-      <p>{currentDate}</p>
+      <p className="no-margin">{currentDate}</p>
+      <p className="no-margin">{currentTime}</p>
       <div className={classes}>
         <WeatherTempWindow
           weatherDescription={currentWeather.description}

--- a/src/hooks/useGetDetailedForecast.ts
+++ b/src/hooks/useGetDetailedForecast.ts
@@ -27,9 +27,5 @@ export const useGetDetailedForecast = (city: string) => {
     }
   }
 
-  if (detailedForecast.length > 5) {
-    detailedForecast = detailedForecast.slice(1);
-  }
-
   return { cityName, timezoneOffset, detailedForecast, isPending };
 };

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -43,8 +43,18 @@ export const getTodayLongDate = () => {
   });
 };
 
-export const formatLocalTime = (timestamp: number, timezoneOffset: number) => {
-  return new Date((timestamp + timezoneOffset) * 1000).toLocaleTimeString([], {
+export const getTodayTime = () => {
+  return (
+    new Date().toLocaleTimeString("en-gb"),
+    {
+      hour: "2-digit",
+      minute: "2-digit",
+    }
+  );
+};
+
+export const formatLocalTime = (date: Date) => {
+  return date.toLocaleTimeString("en-US", {
     hour: "2-digit",
     minute: "2-digit",
     hour12: true,


### PR DESCRIPTION
# Core changes
Add local time to homepage to see the time right now in the current city displayed. This is to add clarity to the forecast data. 